### PR TITLE
fix tracking roi not match objected roi

### DIFF
--- a/object_analytics_node/include/object_analytics_node/tracker/tracking.hpp
+++ b/object_analytics_node/include/object_analytics_node/tracker/tracking.hpp
@@ -65,9 +65,11 @@ public:
    * @brief Rectify tracker with the roi of the detected object.
    *
    * @param[in] mat The detection frame.
-   * @param[in] rect Roi of the detected object.
+   * @param[in] tracked_rect Roi of the tracked object.
+   * @param[in] detected_rect Roi of the detected object.
    */
-  void rectifyTracker(const cv::Mat& mat, const cv::Rect2d& rect);
+  void rectifyTracker(const cv::Mat& mat, const cv::Rect2d& tracked_rect, 
+                      const cv::Rect2d& detected_rect);
 
   /**
    * @brief Update tracker with the tracking frame.
@@ -82,7 +84,7 @@ public:
    *
    * @return Roi of the tracked object.
    */
-  cv::Rect2d getRect();
+  cv::Rect2d getTrackedRect();
 
   /**
    * @brief Get the name of the tracked object.
@@ -90,6 +92,13 @@ public:
    * @return Name of the tracked object.
    */
   std::string getObjName();
+
+  /**
+   * @brief Get the roi of the detected object.
+   *
+   * @return Roi of the detected object.
+   */
+  cv::Rect2d getDetectedRect();
 
   /**
    * @brief Get the tracking id.
@@ -125,8 +134,9 @@ public:
 private:
   static const int32_t kAgeingThreshold; /**< The maximum ageing of an active tracking.*/
   cv::Ptr<cv::Tracker> tracker_;         /**< Tracker associated to this tracking.*/
-  cv::Rect2d rect_;                      /**< Roi of the tracked object.*/
+  cv::Rect2d tracked_rect_;              /**< Roi of the tracked object.*/
   std::string obj_name_;                 /**< Name of the tracked object.*/
+  cv::Rect2d detected_rect_;             /**< Roi of the detected object. */
   int32_t tracking_id_;                  /**< ID of this tracking.*/
   int32_t ageing_;                       /**< Age of this tracking.*/
   bool detected_;                        /**< Detected status of this tracking.*/

--- a/object_analytics_node/include/object_analytics_node/tracker/tracking_manager.hpp
+++ b/object_analytics_node/include/object_analytics_node/tracker/tracking_manager.hpp
@@ -47,7 +47,7 @@ namespace tracker
  *
  * TrackingManager also maintains a @ref kProbabilityThreshold, only when detected with a confidence level not less
  * than this threshold will the object be added to the tracking list. This is necessary to mask any unexpected or
- * unstable  detection results.
+ * unstable detection results.
  *
  * Paralleling computation is enabled in TrackingManager, supported by openmp from compilers. @ref kNumOfThread
  * specifies the number of threads used for paralleling computation. Usually this should be less than the maximum
@@ -115,10 +115,10 @@ private:
    * of the same object across frames. Then the tracking_cnt automatically increases by one.
    *
    * @param[in] obj_name Name of the object (e.g. people, dog, etc.).
-   * @param[in] roi Bounding box of the object.
+   * @param[in] rect Roi of the tracked object.
    * @return Pointer to the tracking added.
    */
-  std::shared_ptr<Tracking> addTracking(const std::string& obj_name, const cv::Rect2d& roi);
+  std::shared_ptr<Tracking> addTracking(const std::string& obj_name, const cv::Rect2d& rect);
 
   /**
    * @brief Clean up inactive tracking in the list.

--- a/object_analytics_node/src/tracker/tracking.cpp
+++ b/object_analytics_node/src/tracker/tracking.cpp
@@ -23,7 +23,7 @@ namespace tracker
 const int32_t Tracking::kAgeingThreshold = 16;
 
 Tracking::Tracking(int32_t tracking_id, const std::string& name, const cv::Rect2d& rect)
-  : tracker_(cv::Ptr<cv::Tracker>()), rect_(rect), obj_name_(name), tracking_id_(tracking_id), detected_(false)
+  : tracker_(cv::Ptr<cv::Tracker>()), tracked_rect_(rect), obj_name_(name), tracking_id_(tracking_id), detected_(false)
 {
 }
 
@@ -35,7 +35,7 @@ Tracking::~Tracking()
   }
 }
 
-void Tracking::rectifyTracker(const cv::Mat& mat, const cv::Rect2d& rect)
+void Tracking::rectifyTracker(const cv::Mat& mat, const cv::Rect2d& t_rect, const cv::Rect2d& d_rect)
 {
   if (tracker_.get())
   {
@@ -46,25 +46,31 @@ void Tracking::rectifyTracker(const cv::Mat& mat, const cv::Rect2d& rect)
 #else
   tracker_ = cv::TrackerMIL::create();
 #endif
-  tracker_->init(mat, rect);
-  rect_ = rect;
+  tracker_->init(mat, t_rect);
+  tracked_rect_ = t_rect;
+  detected_rect_ = d_rect;
 }
 
 bool Tracking::updateTracker(const cv::Mat& mat)
 {
-  bool ret = tracker_->update(mat, rect_);
+  bool ret = tracker_->update(mat, tracked_rect_);
   ageing_++;
   return ret;
 }
 
-cv::Rect2d Tracking::getRect()
+cv::Rect2d Tracking::getTrackedRect()
 {
-  return rect_;
+  return tracked_rect_;
 }
 
 std::string Tracking::getObjName()
 {
   return obj_name_;
+}
+
+cv::Rect2d Tracking::getDetectedRect()
+{
+  return detected_rect_;
 }
 
 int32_t Tracking::getTrackingId()


### PR DESCRIPTION
tracking will change objects roi because of size boundary.
Backup objected roi before handle tracking, after tracking handled, restore objected roi,
so that the roi of tracking and objected could match.

Signed-off-by: Chris Ye <chris.ye@intel.com>