### PR TITLE
fix roi malposition issue in segement

### DIFF
--- a/object_analytics_launch/launch/analytics_movidius_ncs.py
+++ b/object_analytics_launch/launch/analytics_movidius_ncs.py
@@ -34,5 +34,6 @@ def launch(launch_descriptor, argv):
             '--detect-class',                     # detection backend class name, must
             'movidius_ncs_stream::NCSComposition'
         ],
+        name='oa_composition',
     )
     return ld

--- a/object_analytics_node/src/model/object_utils.cpp
+++ b/object_analytics_node/src/model/object_utils.cpp
@@ -122,7 +122,7 @@ double ObjectUtils::getMatch(const cv::Rect2d& r1, const cv::Rect2d& r2)
 {
   cv::Rect2i ir1(r1), ir2(r2);
   /* calculate center of rectangle #1*/
-  cv::Point2i c1(ir1.x + (ir1.width >> 1), ir1.y + (ir1.height >> 1));
+  cv::Point2i c1(ir1.x, ir1.y);
   /* calculate center of rectangle #2*/
   cv::Point2i c2(ir2.x + (ir2.width >> 1), ir2.y + (ir2.height >> 1));
 


### PR DESCRIPTION
movidious_ncs has changed roi.x_offset,roi.y_offset position from left_top to center of rectangle, so OA need to update code to match the roi position.

Signed-off-by: Chris Ye <chris.ye@intel.com>