### PR TITLE
splite pointcloud2 to rgb and xyz

### DIFF
--- a/object_analytics_node/include/object_analytics_node/model/object3d.hpp
+++ b/object_analytics_node/include/object_analytics_node/model/object3d.hpp
@@ -31,7 +31,7 @@ namespace object_analytics_node
 {
 namespace model
 {
-using PointT = pcl::PointXYZRGBA;
+using PointT = pcl::PointXYZ;
 using PointCloudT = pcl::PointCloud<PointT>;
 
 /** @class Object3D

--- a/object_analytics_node/include/object_analytics_node/segmenter/algorithm.hpp
+++ b/object_analytics_node/include/object_analytics_node/segmenter/algorithm.hpp
@@ -43,8 +43,8 @@ public:
    * @param[out]  cloud_segment   Point cloud contains all individuals
    * @param[out]  cluster_indices Indices vector, each indidcates an individual in cloud_segment
    */
-  virtual void segment(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& cloud,
-                       pcl::PointCloud<pcl::PointXYZRGBA>::Ptr& cloud_segment,
+  virtual void segment(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& cloud,
+                       pcl::PointCloud<pcl::PointXYZ>::Ptr& cloud_segment,
                        std::vector<pcl::PointIndices>& cluster_indices) = 0;
 };
 }  // namespace segmenter

--- a/object_analytics_node/include/object_analytics_node/segmenter/organized_multi_plane_segmenter.hpp
+++ b/object_analytics_node/include/object_analytics_node/segmenter/organized_multi_plane_segmenter.hpp
@@ -42,7 +42,7 @@ namespace object_analytics_node
 {
 namespace segmenter
 {
-using PointT = pcl::PointXYZRGBA;
+using PointT = pcl::PointXYZ;
 using PointCloudT = pcl::PointCloud<PointT>;
 using object_analytics_node::segmenter::AlgorithmConfig;
 

--- a/object_analytics_node/include/object_analytics_node/splitter/splitter.hpp
+++ b/object_analytics_node/include/object_analytics_node/splitter/splitter.hpp
@@ -50,6 +50,15 @@ public:
    */
   static void split(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& points,
                     sensor_msgs::msg::Image::SharedPtr& image);
+
+  /**
+   * @brief Split PointCloud2 w/ XYZRGB to XYZ.
+   *
+   * param[in]      points  Pointer to PointCloud2 w/ XYZRGB
+   * param[out]     points  Pointer to PointCloud2 w/ XYZ
+   */
+  static void splitPointsToXYZ(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& points,
+                    sensor_msgs::msg::PointCloud2::SharedPtr& points_xyz);
 };
 }  // namespace splitter
 }  // namespace object_analytics_node

--- a/object_analytics_node/src/segmenter/organized_multi_plane_segmenter.cpp
+++ b/object_analytics_node/src/segmenter/organized_multi_plane_segmenter.cpp
@@ -19,7 +19,8 @@
 #include <pcl/filters/impl/conditional_removal.hpp>
 #include <pcl/filters/impl/filter.hpp>
 #include <pcl/search/impl/organized.hpp>
-#include <pcl/segmentation/impl/organized_connected_component_segmentation.hpp>
+//#include <pcl/segmentation/impl/organized_connected_component_segmentation.hpp>
+//#include <pcl/segmentation/organized_connected_component_segmentation.h>
 #include <rcutils/logging_macros.h>
 #include "object_analytics_node/const.hpp"
 #include "object_analytics_node/segmenter/organized_multi_plane_segmenter.hpp"
@@ -38,7 +39,6 @@ OrganizedMultiPlaneSegmenter::OrganizedMultiPlaneSegmenter()
   : conf_(AlgorithmConfig())
   , plane_comparator_(new pcl::PlaneCoefficientComparator<PointT, Normal>)
   , euclidean_comparator_(new pcl::EuclideanPlaneCoefficientComparator<PointT, Normal>)
-  , rgb_comparator_(new pcl::RGBPlaneCoefficientComparator<PointT, Normal>)
   , edge_aware_comparator_(new pcl::EdgeAwarePlaneComparator<PointT, Normal>)
   , euclidean_cluster_comparator_(new pcl::EuclideanClusterComparator<PointT, Normal, Label>)
 {
@@ -159,10 +159,6 @@ void OrganizedMultiPlaneSegmenter::applyConfig()
   else if (comparator == "EuclideanPlaneCoefficientComparator")
   {
     plane_segmentation_.setComparator(euclidean_comparator_);
-  }
-  else if (comparator == "RGBPlaneCoefficientComparator")
-  {
-    plane_segmentation_.setComparator(rgb_comparator_);
   }
   else if (comparator == "EdgeAwarePlaneComaprator")
   {

--- a/object_analytics_node/src/splitter/splitter.cpp
+++ b/object_analytics_node/src/splitter/splitter.cpp
@@ -16,6 +16,7 @@
 #define PCL_NO_PRECOMPILE
 #include <string>
 #include <pcl_conversions/pcl_conversions.h>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
 #include "object_analytics_node/model/object3d.hpp"
 #include "object_analytics_node/splitter/splitter.hpp"
 
@@ -32,5 +33,37 @@ void Splitter::split(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& points
   pcl::toROSMsg(*points, *image);
   image->header = header;
 }
+
+void
+Splitter::splitPointsToXYZ(const sensor_msgs::msg::PointCloud2::ConstSharedPtr& pointsXYZRGB,
+                        sensor_msgs::msg::PointCloud2::SharedPtr& pointsXYZ)
+{
+  pointsXYZ->header.stamp = pointsXYZRGB->header.stamp;
+  pointsXYZ->header.frame_id = pointsXYZRGB->header.frame_id;
+  pointsXYZ->width = pointsXYZRGB->width;
+  pointsXYZ->height = pointsXYZRGB->height;
+  pointsXYZ->is_dense = false;
+
+  sensor_msgs::PointCloud2Modifier modifier(*pointsXYZ);
+
+  modifier.setPointCloud2FieldsByString(1, "xyz");
+
+  sensor_msgs::PointCloud2Iterator<float> out_x(*pointsXYZ, "x");
+  sensor_msgs::PointCloud2Iterator<float> out_y(*pointsXYZ, "y");
+  sensor_msgs::PointCloud2Iterator<float> out_z(*pointsXYZ, "z");
+
+  sensor_msgs::PointCloud2ConstIterator<float> in_x(*pointsXYZRGB, "x");
+  sensor_msgs::PointCloud2ConstIterator<float> in_y(*pointsXYZRGB, "y");
+  sensor_msgs::PointCloud2ConstIterator<float> in_z(*pointsXYZRGB, "z");
+
+  for (size_t i = 0; i < pointsXYZ->height * pointsXYZ->width; ++i,
+       ++out_x, ++out_y, ++out_z, ++in_x, ++in_y, ++in_z)
+  {
+    *out_x = *in_x;
+    *out_y = *in_y;
+    *out_z = *in_z;
+  }
+}
+
 }  // namespace splitter
 }  // namespace object_analytics_node

--- a/object_analytics_node/src/splitter/splitter_node.cpp
+++ b/object_analytics_node/src/splitter/splitter_node.cpp
@@ -31,7 +31,10 @@ SplitterNode::SplitterNode() : Node("SplitterNode")
       sensor_msgs::msg::Image::SharedPtr image = std::make_shared<sensor_msgs::msg::Image>();
       Splitter::split(points, image);
       pub_2d_->publish(image);
-      pub_3d_->publish(points);
+
+      sensor_msgs::msg::PointCloud2::SharedPtr pointsXYZ = std::make_shared<sensor_msgs::msg::PointCloud2>();
+      Splitter::splitPointsToXYZ(points, pointsXYZ);
+      pub_3d_->publish(pointsXYZ);
     }
     catch (const std::runtime_error& e)
     {

--- a/object_analytics_node/tests/unittest_segmenter.cpp
+++ b/object_analytics_node/tests/unittest_segmenter.cpp
@@ -34,8 +34,8 @@ public:
   Algo() = default;
   ~Algo() = default;
 
-  void segment(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& cloud,
-               pcl::PointCloud<pcl::PointXYZRGBA>::Ptr& cloud_segment, std::vector<pcl::PointIndices>& cluster_indices)
+  void segment(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& cloud,
+               pcl::PointCloud<pcl::PointXYZ>::Ptr& cloud_segment, std::vector<pcl::PointIndices>& cluster_indices)
   {
     pcl::PointIndices indices;
     for (int i = 0; i < 15; i++)


### PR DESCRIPTION
Currently localization using pcl segementation api which not required rgb,

this patch splited Pointcloud2 to XYZ, reduced half size of PointCloud2 (from 9.83M reduce to 4.91M)

imporved pointcloud2 sub-pub transport performance.

Signed-off-by: Chris Ye <chris.ye@intel.com>