### PR TITLE
Merge detected object in localization and tracking

### DIFF
--- a/object_analytics_msgs/CMakeLists.txt
+++ b/object_analytics_msgs/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(ament_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(object_msgs REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
@@ -37,7 +38,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ObjectsInBoxes3D.msg"
   "msg/TrackedObject.msg"
   "msg/TrackedObjects.msg"
-  DEPENDENCIES std_msgs sensor_msgs geometry_msgs
+  DEPENDENCIES std_msgs sensor_msgs geometry_msgs object_msgs
 )
 
 install(

--- a/object_analytics_msgs/msg/ObjectInBox3D.msg
+++ b/object_analytics_msgs/msg/ObjectInBox3D.msg
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # This message can represent a 3D detection object with 2D region of interest and 3D information (min & max)
+object_msgs/Object object             # detected object
 sensor_msgs/RegionOfInterest roi      # region of interest
 geometry_msgs/Point32 min             # min and max locate the diagonal of a bounding-box of the detected object whose
 geometry_msgs/Point32 max             # x, y and z axis parellel to the axises correspondingly in camera coordinates

--- a/object_analytics_msgs/msg/TrackedObject.msg
+++ b/object_analytics_msgs/msg/TrackedObject.msg
@@ -14,4 +14,5 @@
 
 # This message can represent a 2D tracking object with 2D region of interest and tracking id.
 int32 id                            # object identifier
+object_msgs/Object object           # detected object
 sensor_msgs/RegionOfInterest roi    # region of interest

--- a/object_analytics_msgs/package.xml
+++ b/object_analytics_msgs/package.xml
@@ -28,6 +28,7 @@ limitations under the License.
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>std_msgs</build_depend>
+  <build_depend>object_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>builtin_interfaces</build_depend>
@@ -35,6 +36,7 @@ limitations under the License.
 
 
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>object_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/object_analytics_node/include/object_analytics_node/model/object3d.hpp
+++ b/object_analytics_node/include/object_analytics_node/model/object3d.hpp
@@ -97,6 +97,16 @@ public:
   }
 
   /**
+   * Get the underlying object_msgs::Object.
+   *
+   * @return The underlying object_msgs::Object
+   */
+  inline object_msgs::msg::Object getObject() const
+  {
+    return object_;
+  }
+
+  /**
    * Overload operator << to dump information of underlying information.
    *
    * @param[in,out] os    Standard output stream
@@ -110,6 +120,7 @@ private:
   sensor_msgs::msg::RegionOfInterest roi_;
   geometry_msgs::msg::Point32 min_;
   geometry_msgs::msg::Point32 max_;
+  object_msgs::msg::Object object_;
 };
 
 using Object3DPtr = std::shared_ptr<Object3D>;

--- a/object_analytics_node/include/object_analytics_node/tracker/tracking.hpp
+++ b/object_analytics_node/include/object_analytics_node/tracker/tracking.hpp
@@ -52,9 +52,10 @@ public:
    *
    * @param[in] tracking_id ID of this tracking.
    * @param[in] name Name of the tracked object.
+   * @param[in] probability of the tracked object.
    * @param[in] rect Roi of the tracked object.
    */
-  explicit Tracking(int32_t tracking_id, const std::string& name, const cv::Rect2d& rect);
+  explicit Tracking(int32_t tracking_id, const std::string& name, const float& probability, const cv::Rect2d& rect);
 
   /**
    * @brief Default destructor.
@@ -68,7 +69,7 @@ public:
    * @param[in] tracked_rect Roi of the tracked object.
    * @param[in] detected_rect Roi of the detected object.
    */
-  void rectifyTracker(const cv::Mat& mat, const cv::Rect2d& tracked_rect, 
+  void rectifyTracker(const cv::Mat& mat, const cv::Rect2d& tracked_rect,
                       const cv::Rect2d& detected_rect);
 
   /**
@@ -92,6 +93,13 @@ public:
    * @return Name of the tracked object.
    */
   std::string getObjName();
+
+  /**
+   * @brief Get the probability of the tracked object.
+   *
+   * @return probability of the tracked object.
+   */
+  float getObjProbability();
 
   /**
    * @brief Get the roi of the detected object.
@@ -136,6 +144,7 @@ private:
   cv::Ptr<cv::Tracker> tracker_;         /**< Tracker associated to this tracking.*/
   cv::Rect2d tracked_rect_;              /**< Roi of the tracked object.*/
   std::string obj_name_;                 /**< Name of the tracked object.*/
+  float probability_;                    /**< Probability of the tracked object.*/
   cv::Rect2d detected_rect_;             /**< Roi of the detected object. */
   int32_t tracking_id_;                  /**< ID of this tracking.*/
   int32_t ageing_;                       /**< Age of this tracking.*/

--- a/object_analytics_node/include/object_analytics_node/tracker/tracking_manager.hpp
+++ b/object_analytics_node/include/object_analytics_node/tracker/tracking_manager.hpp
@@ -115,10 +115,11 @@ private:
    * of the same object across frames. Then the tracking_cnt automatically increases by one.
    *
    * @param[in] obj_name Name of the object (e.g. people, dog, etc.).
+   * @param[in] probability the object.
    * @param[in] rect Roi of the tracked object.
    * @return Pointer to the tracking added.
    */
-  std::shared_ptr<Tracking> addTracking(const std::string& obj_name, const cv::Rect2d& rect);
+  std::shared_ptr<Tracking> addTracking(const std::string& obj_name, const float& probability, const cv::Rect2d& rect);
 
   /**
    * @brief Clean up inactive tracking in the list.

--- a/object_analytics_node/src/merger/merger.cpp
+++ b/object_analytics_node/src/merger/merger.cpp
@@ -44,6 +44,7 @@ void Merger::composeResult(const RelationVector& relations, ObjectsInBoxes3D::Sh
   for (auto item : relations)
   {
     object_analytics_msgs::msg::ObjectInBox3D obj3d;
+    obj3d.object = item.first.getObject();
     obj3d.roi = item.first.getRoi();
     obj3d.min = item.second.getMin();
     obj3d.max = item.second.getMax();

--- a/object_analytics_node/src/model/object3d.cpp
+++ b/object_analytics_node/src/model/object3d.cpp
@@ -46,7 +46,7 @@ Object3D::Object3D(const PointCloudT::ConstPtr& cloud, const std::vector<int>& i
 }
 
 Object3D::Object3D(const object_analytics_msgs::msg::ObjectInBox3D& object3d)
-  : roi_(object3d.roi), min_(object3d.min), max_(object3d.max)
+  : roi_(object3d.roi), min_(object3d.min), max_(object3d.max), object_(object3d.object)
 {
 }
 

--- a/object_analytics_node/src/tracker/tracking.cpp
+++ b/object_analytics_node/src/tracker/tracking.cpp
@@ -22,8 +22,9 @@ namespace tracker
 {
 const int32_t Tracking::kAgeingThreshold = 16;
 
-Tracking::Tracking(int32_t tracking_id, const std::string& name, const cv::Rect2d& rect)
-  : tracker_(cv::Ptr<cv::Tracker>()), tracked_rect_(rect), obj_name_(name), tracking_id_(tracking_id), detected_(false)
+Tracking::Tracking(int32_t tracking_id, const std::string& name, const float& probability, const cv::Rect2d& rect)
+  : tracker_(cv::Ptr<cv::Tracker>()), tracked_rect_(rect), obj_name_(name), probability_(probability),
+    tracking_id_(tracking_id), detected_(false)
 {
 }
 
@@ -66,6 +67,11 @@ cv::Rect2d Tracking::getTrackedRect()
 std::string Tracking::getObjName()
 {
   return obj_name_;
+}
+
+float Tracking::getObjProbability()
+{
+  return probability_;
 }
 
 cv::Rect2d Tracking::getDetectedRect()

--- a/object_analytics_node/src/tracker/tracking_manager.cpp
+++ b/object_analytics_node/src/tracker/tracking_manager.cpp
@@ -72,6 +72,7 @@ void TrackingManager::detect(const cv::Mat& mat, const object_msgs::msg::Objects
       continue;
     }
     std::string n = dobj.object_name;
+//    float probability =  dobj.probability;
     sensor_msgs::msg::RegionOfInterest droi = objs->objects_vector[i].roi;
     cv::Rect2d detected_rect = cv::Rect2d(droi.x_offset, droi.y_offset, droi.width, droi.height);
     /* some trackers do not accept an ROI beyond the size of a Mat*/
@@ -97,7 +98,7 @@ void TrackingManager::detect(const cv::Mat& mat, const object_msgs::msg::Objects
       /* add tracking if new object detected*/
       if (!t)
       {
-        t = addTracking(n, tracked_rect);
+        t = addTracking(n, dobj.probability, tracked_rect);
       }
       t->setDetected();
     }
@@ -121,6 +122,8 @@ int32_t TrackingManager::getTrackedObjs(const object_analytics_msgs::msg::Tracke
     object_analytics_msgs::msg::TrackedObject tobj;
     cv::Rect2d r = t->getDetectedRect();
     tobj.id = t->getTrackingId();
+    tobj.object.object_name = t->getObjName();
+    tobj.object.probability = t->getObjProbability();
     tobj.roi.x_offset = static_cast<int>(r.x);
     tobj.roi.y_offset = static_cast<int>(r.y);
     tobj.roi.width = static_cast<int>(r.width);
@@ -132,9 +135,10 @@ int32_t TrackingManager::getTrackedObjs(const object_analytics_msgs::msg::Tracke
   return objs->tracked_objects.size();
 }
 
-std::shared_ptr<Tracking> TrackingManager::addTracking(const std::string& name, const cv::Rect2d& rect)
+std::shared_ptr<Tracking> TrackingManager::addTracking(const std::string& name, const float& probability,
+                                                       const cv::Rect2d& rect)
 {
-  std::shared_ptr<Tracking> t = std::make_shared<Tracking>(tracking_cnt++, name, rect);
+  std::shared_ptr<Tracking> t = std::make_shared<Tracking>(tracking_cnt++, name, probability, rect);
   if (tracking_cnt == -1)
   {
     RCLCPP_WARN(node_->get_logger(), "tracking count overflow");

--- a/object_analytics_node/tests/unittest_merger.cpp
+++ b/object_analytics_node/tests/unittest_merger.cpp
@@ -62,7 +62,7 @@ TEST(UnitTestMerger, merge_Empty2D)
   ObjectsInBoxes3D::SharedPtr objects_in_boxes3d = std::make_shared<ObjectsInBoxes3D>();
   std_msgs::msg::Header header3D = createHeader(builtin_interfaces::msg::Time(), "camera_rgb_optical_frame");
   objects_in_boxes3d->header = header3D;
-  objects_in_boxes3d->objects_in_boxes.push_back(getObjectInBox3D(0, 0, 100, 100, 1, 1, 1, 100, 100, 100));
+  objects_in_boxes3d->objects_in_boxes.push_back(getObjectInBox3D(0, 0, 100, 100, 1, 1, 1, 100, 100, 100, "person", 0.99));
 
   ObjectsInBoxes3D::SharedPtr merged = Merger::merge(objects_in_boxes2d, objects_in_boxes3d);
   EXPECT_TRUE(merged->header == header2D);
@@ -80,7 +80,7 @@ TEST(UnitTestMerger, merge_Normal)
   ObjectsInBoxes3D::SharedPtr objects_in_boxes3d(new ObjectsInBoxes3D);
   std_msgs::msg::Header header3D = createHeader(builtin_interfaces::msg::Time(), "camera_rgb_optical_frame");
   objects_in_boxes3d->header = header3D;
-  ObjectInBox3D person = getObjectInBox3D(0, 0, 100, 100, 1, 1, 1, 100, 100, 100);
+  ObjectInBox3D person = getObjectInBox3D(0, 0, 100, 100, 1, 1, 1, 100, 100, 100, "person", 0.99);
   objects_in_boxes3d->objects_in_boxes.push_back(person);
 
   ObjectsInBoxes3D::SharedPtr merged = Merger::merge(objects_in_boxes2d, objects_in_boxes3d);

--- a/object_analytics_node/tests/unittest_object3d.cpp
+++ b/object_analytics_node/tests/unittest_object3d.cpp
@@ -47,11 +47,12 @@ TEST(UnitTestObject3D, constructor_TwoParameters)
 
 TEST(UnitTestObject3D, constructor_OneParameter)
 {
-  ObjectInBox3D objectInBox3D = getObjectInBox3D(0, 0, 100, 100, 20, 30, 40, 200, 300, 400);
+  ObjectInBox3D objectInBox3D = getObjectInBox3D(0, 0, 100, 100, 20, 30, 40, 200, 300, 400, "person", 0.99);
   Object3D obj3(objectInBox3D);
   EXPECT_TRUE(obj3.getMin() == getPoint32(20, 30, 40));
   EXPECT_TRUE(obj3.getMax() == getPoint32(200, 300, 400));
   EXPECT_TRUE(obj3.getRoi() == getRoi(0, 0, 100, 100));
+  EXPECT_TRUE(obj3.getObject() == getObject("person", 0.99));
 }
 
 int main(int argc, char** argv)

--- a/object_analytics_node/tests/unittest_objectutils.cpp
+++ b/object_analytics_node/tests/unittest_objectutils.cpp
@@ -60,11 +60,11 @@ TEST(UnitTestObjectUtils, fill3DObjects_Empty)
 TEST(UnitTestObjectUtils, fill3DObjects_NormalCase)
 {
   ObjectsInBoxes3D::SharedPtr objects = std::make_shared<ObjectsInBoxes3D>();
-  ObjectInBox3D first = getObjectInBox3D(1, 1, 100, 100, 1, 2, 3, 4, 5, 6);
+  ObjectInBox3D first = getObjectInBox3D(1, 1, 100, 100, 1, 2, 3, 4, 5, 6, "person", 0.99);
   objects->objects_in_boxes.push_back(first);
-  ObjectInBox3D second = getObjectInBox3D(100, 100, 200, 200, 7, 8, 9, 10, 11, 12);
+  ObjectInBox3D second = getObjectInBox3D(100, 100, 200, 200, 7, 8, 9, 10, 11, 12, "person", 0.80);
   objects->objects_in_boxes.push_back(second);
-  ObjectInBox3D third = getObjectInBox3D(320, 480, 1, 1, 13, 14, 15, 16, 17, 18);
+  ObjectInBox3D third = getObjectInBox3D(320, 480, 1, 1, 13, 14, 15, 16, 17, 18, "person", 0.90);
   objects->objects_in_boxes.push_back(third);
   std::vector<Object3D> objects3d;
   ObjectUtils::fill3DObjects(objects, objects3d);
@@ -80,11 +80,11 @@ TEST(UnitTestObjectUtils, findMaxIntersectionRelationships_NormalCase)
   std::vector<Object2D> objects2d;
   std::vector<std::pair<Object2D, Object3D>> relations;
   // build 3d objects
-  Object3D first3d = Object3D(getObjectInBox3D(1, 1, 100, 100, 1, 2, 3, 4, 5, 6));
-  Object3D second3d = Object3D(getObjectInBox3D(1, 102, 100, 100, 1, 2, 3, 4, 5, 6));
-  Object3D third3d = Object3D(getObjectInBox3D(50, 50, 100, 100, 1, 2, 3, 4, 5, 6));
-  Object3D forth3d = Object3D(getObjectInBox3D(200, 0, 30, 40, 1, 2, 3, 4, 5, 6));
-  Object3D fifth3d = Object3D(getObjectInBox3D(49, 49, 60, 60, 1, 2, 3, 4, 5, 6));
+  Object3D first3d = Object3D(getObjectInBox3D(1, 1, 100, 100, 1, 2, 3, 4, 5, 6, "person", 0.90));
+  Object3D second3d = Object3D(getObjectInBox3D(1, 102, 100, 100, 1, 2, 3, 4, 5, 6, "person", 0.80));
+  Object3D third3d = Object3D(getObjectInBox3D(50, 50, 100, 100, 1, 2, 3, 4, 5, 6, "person", 0.70));
+  Object3D forth3d = Object3D(getObjectInBox3D(200, 0, 30, 40, 1, 2, 3, 4, 5, 6, "person", 0.60));
+  Object3D fifth3d = Object3D(getObjectInBox3D(49, 49, 60, 60, 1, 2, 3, 4, 5, 6, "person", 0.50));
   objects3d.push_back(first3d);
   objects3d.push_back(second3d);
   objects3d.push_back(third3d);

--- a/object_analytics_node/tests/unittest_util.cpp
+++ b/object_analytics_node/tests/unittest_util.cpp
@@ -83,12 +83,13 @@ Point32 getPoint32(float x, float y, float z)
 }
 
 ObjectInBox3D getObjectInBox3D(int x_offset, int y_offset, int width, int height, int min_x, int min_y, int min_z,
-                               int max_x, int max_y, int max_z)
+                               int max_x, int max_y, int max_z, const std::string& name, const float probability)
 {
   ObjectInBox3D oib3d;
   oib3d.roi = getRoi(x_offset, y_offset, width, height);
   oib3d.max = getPoint32(max_x, max_y, max_z);
   oib3d.min = getPoint32(min_x, min_y, min_z);
+  oib3d.object = getObject(name, probability);
   return oib3d;
 }
 

--- a/object_analytics_node/tests/unittest_util.hpp.in
+++ b/object_analytics_node/tests/unittest_util.hpp.in
@@ -49,7 +49,7 @@ RegionOfInterest getRoi(int x_offset, int y_offset, int width, int height);
 ObjectInBox getObjectInBox(int x_offset, int y_offset, int width, int height, const std::string& name,
                            const float probability);
 ObjectInBox3D getObjectInBox3D(int x_offset, int y_offset, int width, int height, int min_x, int min_y, int min_z,
-                               int max_x, int max_y, int max_z);
+                               int max_x, int max_y, int max_z, const std::string& name, const float probability);
 
 Point32 getPoint32(float x, float y, float z);
 PointT getPointT(float x, float y, float z);

--- a/object_analytics_rviz/src/image_publisher.cpp
+++ b/object_analytics_rviz/src/image_publisher.cpp
@@ -35,7 +35,6 @@ using namespace std::chrono_literals;
 using std::placeholders::_1;
 
 using ImageMsg = sensor_msgs::msg::Image;
-using DetectionMsg = object_msgs::msg::ObjectsInBoxes;
 using TrackingMsg = object_analytics_msgs::msg::TrackedObjects;
 using LocalizationMsg = object_analytics_msgs::msg::ObjectsInBoxes3D;
 
@@ -45,7 +44,7 @@ using TrackingObjectInBox = object_analytics_msgs::msg::TrackedObject;
 using LocalizationObjectInBox = object_analytics_msgs::msg::ObjectInBox3D;
 
 /* This demo code is desiged for showing object analytics result on rviz.
- * Subscribe image/detection/tracking msg, publish tracking 2d box for display. */
+ * Subscribe image/tracking msg, publish tracking 2d box for display. */
 
 class ImagePublisher : public rclcpp::Node
 {
@@ -55,11 +54,10 @@ public:
   {
 
     f_image_sub_= std::make_unique<FilteredLocalization>(this, kTopicImage_);
-    f_detection_sub_ = std::make_unique<FilteredDetection>(this, kTopicDetection_);
     f_tracking_sub_ = std::make_unique<FilteredTracking>(this, kTopicTracking_);
 
     sync_sub_ =
-        std::make_unique<FilteredSync>(*f_image_sub_, *f_detection_sub_, *f_tracking_sub_, 10);
+        std::make_unique<FilteredSync>(*f_image_sub_, *f_tracking_sub_, 10);
     sync_sub_->registerCallback(&ImagePublisher::onObjectsReceived, this);
 
     image_pub_ = create_publisher<ImageMsg>("/object_analytics/image_publisher");
@@ -67,8 +65,6 @@ public:
     RCLCPP_INFO(get_logger(), "Start ImagePublisher ...");
 
     // subscribe those topics for performance test
-    det_subscription_ = this->create_subscription<DetectionMsg>(
-      kTopicDetection_, std::bind(&ImagePublisher::det_callback, this, _1));
     tra_subscription_ = this->create_subscription<TrackingMsg>(
       kTopicTracking_, std::bind(&ImagePublisher::tra_callback, this, _1));
     loc_subscription_ = this->create_subscription<LocalizationMsg>(
@@ -77,59 +73,44 @@ public:
 
 private:
   using ObjectRoi = sensor_msgs::msg::RegionOfInterest;
-  using FilteredDetection = message_filters::Subscriber<DetectionMsg>;
   using FilteredTracking = message_filters::Subscriber<TrackingMsg>;
   using FilteredLocalization = message_filters::Subscriber<ImageMsg>;
   using FilteredSync =
-      message_filters::TimeSynchronizer<ImageMsg, DetectionMsg, TrackingMsg>;
+      message_filters::TimeSynchronizer<ImageMsg, TrackingMsg>;
 
-  std::unique_ptr<FilteredDetection> f_detection_sub_;
   std::unique_ptr<FilteredTracking> f_tracking_sub_;
   std::unique_ptr<FilteredLocalization> f_image_sub_;
   std::unique_ptr<FilteredSync> sync_sub_;
 
-  const std::string kTopicDetection_ = "/movidius_ncs_stream/detected_objects";
   const std::string kTopicImage_ = "/object_analytics/rgb";
   const std::string kTopicTracking_ = "/object_analytics/tracking";
   const std::string kTopicLocalization_ = "/object_analytics/localization";
 
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
   rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Subscription<DetectionMsg>::SharedPtr det_subscription_;
   rclcpp::Subscription<TrackingMsg>::SharedPtr tra_subscription_;
   rclcpp::Subscription<LocalizationMsg>::SharedPtr loc_subscription_;
   rclcpp::Publisher<ImageMsg>::SharedPtr image_pub_;
 
-  float det_latency_;
-  float det_fps_;
   float tra_latency_;
   float tra_fps_;
   float loc_latency_;
   float loc_fps_;
 
-  /* after messages filter, receive msgs from img/det/tra three topics */
+  /* after messages filter, receive msgs from img/tra three topics */
   void onObjectsReceived(const ImageMsg::SharedPtr& img,
-                         const DetectionMsg::SharedPtr& det,
                          const TrackingMsg::SharedPtr& tra)
   {
-
-    RCLCPP_DEBUG(this->get_logger(), "[Object Vectors size: I=(%d,%d), T=%d, L=%d]",
-                img->width, img->height, det->objects_vector.size(),
-                tra->tracked_objects.size());
-
-    if (img->header.stamp != tra->header.stamp || tra->header.stamp != det->header.stamp ||
-        img->header.stamp != det->header.stamp)
+    if (img->header.stamp != tra->header.stamp)
     {
       RCLCPP_WARN(get_logger(), "...Doesn't meet the stamp check, do nothing for the current \
       messages");
-      RCLCPP_WARN(get_logger(), "......D==%ld.%ld, T==%ld.%ld, L==%ld.%ld", det->header.stamp.sec,
-                  det->header.stamp.nanosec, tra->header.stamp.sec, tra->header.stamp.nanosec,
+      RCLCPP_WARN(get_logger(), "...... T==%ld.%ld, L==%ld.%ld",
+                  tra->header.stamp.sec, tra->header.stamp.nanosec,
                   img->header.stamp.sec, img->header.stamp.nanosec);
       return;
     }
-    if (img->header.frame_id != tra->header.frame_id ||
-        tra->header.frame_id != det->header.frame_id ||
-        img->header.frame_id != det->header.frame_id)
+    if (img->header.frame_id != tra->header.frame_id)
     {
       RCLCPP_WARN(get_logger(), "...Doesn't meet the frame_id check, do nothing for the current \
       messages");
@@ -138,41 +119,32 @@ private:
 
 
     cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(img, "bgr8");
-    if (cv_ptr->image.size != 0 && tra->tracked_objects.size() != 0 &&
-        det->objects_vector.size() != 0)
+    if (cv_ptr->image.size != 0 && tra->tracked_objects.size() != 0)
     {
-      cv_ptr->header = det->header;
-      std::vector<DetectionObjectInBox> objects_detected;
+      cv_ptr->header = tra->header;
       std::vector<TrackingObjectInBox> objects_tracked;
-      objects_detected = det->objects_vector;
       objects_tracked = tra->tracked_objects;
 
-      findObject(cv_ptr, objects_detected, objects_tracked);
+      findObject(cv_ptr, objects_tracked);
     }
   }
 
-  /* Find object with same ROI */
+  /* Find object with ROI */
   void findObject(cv_bridge::CvImagePtr cv_ptr,
-                  std::vector<DetectionObjectInBox> det_objects,
                   std::vector<TrackingObjectInBox> tra_objects)
   {
     // make sure all the msgs are none-empty
-    for(auto det : det_objects)
+    for(auto tra : tra_objects)
     {
-      ObjectRoi roi = det.roi;
-      for(auto tra : tra_objects)
+      ObjectRoi roi = tra.roi;
+      if(roi.x_offset != 0 && roi.y_offset != 0 && roi.width != 0 && roi.height != 0)
       {
-        if(roi.x_offset == tra.roi.x_offset && roi.y_offset == tra.roi.y_offset &&
-            roi.width == tra.roi.width && roi.height == tra.roi.height)
-        {
 
-          std::string obj_name = det.object.object_name;
-          drawObject(cv_ptr, roi, obj_name, tra.id);
-          // print performance date
-          //RCLCPP_INFO(this->get_logger(),
-          //            "Performance: [L] fps %.3f hz, latency %.3f sec [D] fps %.3f hz, latency %.3f sec [T] fps %.3f hz, latency %.3f sec",
-          //            loc_fps_, loc_latency_, det_fps_, det_latency_, tra_fps_, tra_latency_);
-        }
+        std::string obj_name = tra.object.object_name;
+        drawObject(cv_ptr, roi, obj_name, tra.id);
+        RCLCPP_DEBUG(this->get_logger(),
+                    "Performance: [L] fps %.3f hz, latency %.3f sec [T] fps %.3f hz, latency %.3f sec",
+                    loc_fps_, loc_latency_, tra_fps_, tra_latency_);
       }
     }
   }
@@ -203,56 +175,16 @@ private:
                     cv::Scalar(0, 255, 0), 1);
 
         // Draw measure result on the left up
-        char ss_det[100];
-        snprintf(ss_det, sizeof(ss_det), "Detection:fps=%.2fHz,latency=%.2fSec", det_fps_, det_latency_);
-        cv::putText(cv_ptr->image, ss_det, cvPoint(2, 15), cv::FONT_HERSHEY_SIMPLEX, 0.5,
-                    cv::Scalar(255, 0, 0), 1);
         char ss_tra[100];
         snprintf(ss_tra, sizeof(ss_tra), "Tracking:fps=%.2fHz,latency=%.2fSec", tra_fps_, tra_latency_);
-        cv::putText(cv_ptr->image, ss_tra, cvPoint(2, 15*2), cv::FONT_HERSHEY_SIMPLEX, 0.5,
+        cv::putText(cv_ptr->image, ss_tra, cvPoint(2, 15), cv::FONT_HERSHEY_SIMPLEX, 0.5,
                     cv::Scalar(255, 0, 0), 1);
         char ss_loc[100];
         snprintf(ss_loc, sizeof(ss_loc), "Localization:fps=%.2fHz,latency=%.2fSec", loc_fps_, loc_latency_);
-        cv::putText(cv_ptr->image, ss_loc, cvPoint(2, 15*3), cv::FONT_HERSHEY_SIMPLEX, 0.5,
+        cv::putText(cv_ptr->image, ss_loc, cvPoint(2, 30), cv::FONT_HERSHEY_SIMPLEX, 0.5,
                     cv::Scalar(255, 0, 0), 1);
 
         image_pub_->publish(cv_ptr->toImageMsg());
-  }
-
-  /* detection callback for performance test */
-  void det_callback(const DetectionMsg::SharedPtr msg)
-  {
-    struct timespec time_start={0, 0};
-    clock_gettime(CLOCK_REALTIME, &time_start);
-    static double last_sec = 0;
-    static double last_nsec = 0;
-    static int count = 0;
-    double interval = 0;
-    double current_sec = time_start.tv_sec;
-    double current_nsec = time_start.tv_nsec;
-    double msg_sec = msg->header.stamp.sec;
-    double msg_nsec = msg->header.stamp.nanosec;
-
-    count++;
-    interval = (current_sec - last_sec) + ((current_nsec - last_nsec)/1000000000);
-    if(last_sec == 0)
-    {
-       last_sec = current_sec;
-       last_nsec = current_nsec;
-       return;
-    }
-
-    if(interval >= 1.0)
-    {
-        double latency = (current_sec - msg_sec) + ((current_nsec - msg_nsec)/1000000000);
-        double fps = count/interval;
-        count = 0;
-        last_sec = current_sec;
-        last_nsec = current_nsec;
-        RCLCPP_DEBUG(this->get_logger(), "D: fps %.3f hz, latency %.3f sec", fps, latency)
-        det_fps_ = fps;
-        det_latency_ = latency;
-    }
   }
 
   /* localization callback for performance test */
@@ -316,14 +248,14 @@ private:
 
     if(interval >= 1.0)
     {
-        double latency = (current_sec - msg_sec) + ((current_nsec - msg_nsec)/1000000000);
-        double fps = count/interval;
-        count = 0;
-        last_sec = current_sec;
-        last_nsec = current_nsec;
-        RCLCPP_DEBUG(this->get_logger(), "T: fps %.3f hz, latency %.3f sec", fps, latency)
-        tra_fps_ = fps;
-        tra_latency_ = latency;
+       double latency = (current_sec - msg_sec) + ((current_nsec - msg_nsec)/1000000000);
+       double fps = count/interval;
+       count = 0;
+       last_sec = current_sec;
+       last_nsec = current_nsec;
+       RCLCPP_DEBUG(this->get_logger(), "T: fps %.3f hz, latency %.3f sec", fps, latency)
+       tra_fps_ = fps;
+       tra_latency_ = latency;
     }
   }
 };

--- a/object_analytics_rviz/src/marker_publisher.cpp
+++ b/object_analytics_rviz/src/marker_publisher.cpp
@@ -34,17 +34,14 @@
 using namespace std::chrono_literals;
 using std::placeholders::_1;
 
-using DetectionMsg = object_msgs::msg::ObjectsInBoxes;
 using TrackingMsg = object_analytics_msgs::msg::TrackedObjects;
 using LocalizationMsg = object_analytics_msgs::msg::ObjectsInBoxes3D;
 
-using DetectionObject = object_msgs::msg::Object;
-using DetectionObjectInBox = object_msgs::msg::ObjectInBox;
 using TrackingObjectInBox = object_analytics_msgs::msg::TrackedObject;
 using LocalizationObjectInBox = object_analytics_msgs::msg::ObjectInBox3D;
 
 /* This demo code is desiged for showing object analytics result on rviz.
- * Subscribe detection/localization/tracking msg, publish box_3d_markers for display. */
+ * Subscribe localization/tracking msg, publish box_3d_markers for display. */
 
 class MarkerPublisher : public rclcpp::Node
 {
@@ -54,17 +51,14 @@ public:
   {
     loc_subscription_ = this->create_subscription<LocalizationMsg>(
       "/object_analytics/localization", std::bind(&MarkerPublisher::loc_callback, this, _1));
-    det_subscription_ = this->create_subscription<DetectionMsg>(
-      "/movidius_ncs_stream/detected_objects", std::bind(&MarkerPublisher::det_callback, this, _1));
     tra_subscription_ = this->create_subscription<TrackingMsg>(
       "/object_analytics/tracking", std::bind(&MarkerPublisher::tra_callback, this, _1));
 
-    f_detection_sub_ = std::make_unique<FilteredDetection>(this, kTopicDetection_);
     f_tracking_sub_ = std::make_unique<FilteredTracking>(this, kTopicTracking_);
     f_localization_sub_ = std::make_unique<FilteredLocalization>(this, kTopicLocalization_);
 
     sync_sub_ =
-        std::make_unique<FilteredSync>(*f_detection_sub_, *f_tracking_sub_, *f_localization_sub_, 10);
+        std::make_unique<FilteredSync>(*f_tracking_sub_, *f_localization_sub_, 10);
     sync_sub_->registerCallback(&MarkerPublisher::onObjectsReceived, this);
 
     marker_pub_ = create_publisher<visualization_msgs::msg::MarkerArray>("/object_analytics/marker_publisher");
@@ -74,24 +68,20 @@ public:
 
 private:
   using ObjectRoi = sensor_msgs::msg::RegionOfInterest;
-  using FilteredDetection = message_filters::Subscriber<DetectionMsg>;
   using FilteredTracking = message_filters::Subscriber<TrackingMsg>;
   using FilteredLocalization = message_filters::Subscriber<LocalizationMsg>;
   using FilteredSync =
-      message_filters::TimeSynchronizer<DetectionMsg, TrackingMsg, LocalizationMsg>;
+      message_filters::TimeSynchronizer<TrackingMsg, LocalizationMsg>;
 
-  std::unique_ptr<FilteredDetection> f_detection_sub_;
   std::unique_ptr<FilteredTracking> f_tracking_sub_;
   std::unique_ptr<FilteredLocalization> f_localization_sub_;
   std::unique_ptr<FilteredSync> sync_sub_;
 
-  const std::string kTopicDetection_ = "/movidius_ncs_stream/detected_objects";
   const std::string kTopicLocalization_ = "/object_analytics/localization";
   const std::string kTopicTracking_ = "/object_analytics/tracking";
 
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
   rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Subscription<DetectionMsg>::SharedPtr det_subscription_;
   rclcpp::Subscription<LocalizationMsg>::SharedPtr loc_subscription_;
   rclcpp::Subscription<TrackingMsg>::SharedPtr tra_subscription_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
@@ -100,108 +90,93 @@ private:
   float loc_fps_;
   float tra_latency_;
   float tra_fps_;
-  float det_latency_;
-  float det_fps_;
 
   /* after messages filter, receive msgs from det/tra/loc three topics */
-  void onObjectsReceived(const DetectionMsg::SharedPtr& det,
-                         const TrackingMsg::SharedPtr& tra,
+  void onObjectsReceived(const TrackingMsg::SharedPtr& tra,
                          const LocalizationMsg::SharedPtr& loc)
   {
-    if (loc->header.stamp != tra->header.stamp || tra->header.stamp != det->header.stamp ||
-        loc->header.stamp != det->header.stamp)
+    if (loc->header.stamp != tra->header.stamp)
     {
       RCLCPP_WARN(get_logger(), "...Doesn't meet the stamp check, do nothing for the current \
       messages");
-      RCLCPP_WARN(get_logger(), "......D==%ld.%ld, T==%ld.%ld, L==%ld.%ld", det->header.stamp.sec,
-                  det->header.stamp.nanosec, tra->header.stamp.sec, tra->header.stamp.nanosec,
+      RCLCPP_WARN(get_logger(), "...... T==%ld.%ld, L==%ld.%ld",
+                  tra->header.stamp.sec, tra->header.stamp.nanosec,
                   loc->header.stamp.sec, loc->header.stamp.nanosec);
       return;
     }
-    if (loc->header.frame_id != tra->header.frame_id ||
-        tra->header.frame_id != det->header.frame_id ||
-        loc->header.frame_id != det->header.frame_id)
+    if (loc->header.frame_id != tra->header.frame_id)
     {
       RCLCPP_WARN(get_logger(), "...Doesn't meet the frame_id check, do nothing for the current \
       messages");
       return;
     }
 
-    processMsg(det, tra, loc);
+    processMsg(tra, loc);
   }
 
   /* Handle msgs */
-  void processMsg(const DetectionMsg::SharedPtr& det,
-                     const TrackingMsg::SharedPtr& tra,
-                     const LocalizationMsg::SharedPtr& loc)
+  void processMsg(const TrackingMsg::SharedPtr& tra,
+                  const LocalizationMsg::SharedPtr& loc)
   {
-    RCLCPP_DEBUG(this->get_logger(), "[Object Vectors size: D=%d, T=%d, L=%d]",
-                det->objects_vector.size(), tra->tracked_objects.size(),
-                loc->objects_in_boxes.size());
+    RCLCPP_DEBUG(this->get_logger(), "[Object Vectors size: T=%d, L=%d]",
+                 tra->tracked_objects.size(), loc->objects_in_boxes.size());
 
     // make sure all the msgs are none-empty
-    if (loc->objects_in_boxes.size() != 0 && tra->tracked_objects.size() != 0 &&
-        det->objects_vector.size() != 0)
+    if (loc->objects_in_boxes.size() != 0 && tra->tracked_objects.size() != 0)
     {
       // print performance date
       RCLCPP_INFO(this->get_logger(),
-                  "Performance: [D] fps %.3f hz, latency %.3f sec [L] fps %.3f hz, latency %.3f sec [T] fps %.3f hz, latency %.3f sec",
-                  det_fps_, det_latency_, loc_fps_, loc_latency_, tra_fps_, tra_latency_);
+                  "Performance: [L] fps %.3f hz, latency %.3f sec [T] fps %.3f hz, latency %.3f sec",
+                   loc_fps_, loc_latency_, tra_fps_, tra_latency_);
 
-      std::vector<DetectionObjectInBox> objects_detected;
       std::vector<TrackingObjectInBox> objects_tracked;
       std::vector<LocalizationObjectInBox> objects_localized;
 
       std_msgs::msg::Header header = loc->header;
-      objects_detected = det->objects_vector;
       objects_tracked = tra->tracked_objects;
       objects_localized = loc->objects_in_boxes;
 
-      MarkerPublisher::findObject(header, objects_detected, objects_tracked, objects_localized);
+      MarkerPublisher::findObject(header, objects_tracked, objects_localized);
     }
   }
 
   /* find object with same roi */
   void findObject(std_msgs::msg::Header header,
-                  std::vector<DetectionObjectInBox> det_objects,
                   std::vector<TrackingObjectInBox> tra_objects,
                   std::vector<LocalizationObjectInBox> loc_objects)
   {
-      for(auto det : det_objects)
+      for(auto tra : tra_objects)
       {
-          ObjectRoi roi = det.roi;
-          for(auto tra : tra_objects)
+          ObjectRoi roi = tra.roi;
+          if(roi.x_offset == tra.roi.x_offset && roi.y_offset == tra.roi.y_offset &&
+                  roi.width == tra.roi.width && roi.height == tra.roi.height)
           {
-              if(roi.x_offset == tra.roi.x_offset && roi.y_offset == tra.roi.y_offset &&
-                      roi.width == tra.roi.width && roi.height == tra.roi.height)
+              for(auto loc : loc_objects)
               {
-                  for(auto loc : loc_objects)
+                  if(loc.min.x == 0 && loc.min.y == 0 && loc.min.z == 0 &&
+                     loc.max.x == 0 && loc.max.y == 0 && loc.max.z == 0)
                   {
-                      if(loc.min.x == 0 && loc.min.y == 0 && loc.min.z == 0 &&
-                         loc.max.x == 0 && loc.max.y == 0 && loc.max.z == 0)
-                      {
-                          break;
-                      }
-
-                      if(roi.x_offset == loc.roi.x_offset && roi.y_offset == loc.roi.y_offset &&
-                         roi.width == loc.roi.width && roi.height == loc.roi.height)
-                      {
-                          geometry_msgs::msg::Point box_min;
-                          box_min.x = loc.min.x;
-                          box_min.y = loc.min.y;
-                          box_min.z = loc.min.z;
-                          geometry_msgs::msg::Point box_max;
-                          box_max.x = loc.max.x;
-                          box_max.y = loc.max.y;
-                          box_max.z = loc.max.z;
-                          std::string obj_name = det.object.object_name;
-                          int32_t obj_id = tra.id;
-
-                          MarkerPublisher::publishMarker(header, box_min, box_max, obj_name, obj_id);
-                      }
+                      break;
                   }
 
+                  if(roi.x_offset == loc.roi.x_offset && roi.y_offset == loc.roi.y_offset &&
+                     roi.width == loc.roi.width && roi.height == loc.roi.height)
+                  {
+                      geometry_msgs::msg::Point box_min;
+                      box_min.x = loc.min.x;
+                      box_min.y = loc.min.y;
+                      box_min.z = loc.min.z;
+                      geometry_msgs::msg::Point box_max;
+                      box_max.x = loc.max.x;
+                      box_max.y = loc.max.y;
+                      box_max.z = loc.max.z;
+                      std::string obj_name = loc.object.object_name;
+                      int32_t obj_id = tra.id;
+
+                      MarkerPublisher::publishMarker(header, box_min, box_max, obj_name, obj_id);
+                  }
               }
+
           }
       }
   }
@@ -378,42 +353,6 @@ private:
     marker.points.push_back(p8);
 
     return marker;
-  }
-
-  /* detection callback for performance test */
-  void det_callback(const DetectionMsg::SharedPtr msg)
-  {
-    struct timespec time_start={0, 0};
-    clock_gettime(CLOCK_REALTIME, &time_start);
-    static double last_sec = 0;
-    static double last_nsec = 0;
-    static int count = 0;
-    double interval = 0;
-    double current_sec = time_start.tv_sec;
-    double current_nsec = time_start.tv_nsec;
-    double msg_sec = msg->header.stamp.sec;
-    double msg_nsec = msg->header.stamp.nanosec;
-
-    count++;
-    interval = (current_sec - last_sec) + ((current_nsec - last_nsec)/1000000000);
-    if(last_sec == 0)
-    {
-       last_sec = current_sec;
-       last_nsec = current_nsec;
-       return;
-    }
-
-    if(interval >= 1.0)
-    {
-        double latency = (current_sec - msg_sec) + ((current_nsec - msg_nsec)/1000000000);
-        double fps = count/interval;
-        count = 0;
-        last_sec = current_sec;
-        last_nsec = current_nsec;
-        RCLCPP_DEBUG(this->get_logger(), "D: fps %.3f hz, latency %.3f sec", fps, latency)
-        det_fps_ = fps;
-        det_latency_ = latency;
-    }
   }
 
   /* localization callback for performance test */


### PR DESCRIPTION
Merged detected object_name and probability in localization and tracking object,

so that users could only subscribe localization or tracking, needn't sub detected object

and needn't do message fileter again.

Signed-off-by: Chris Ye <chris.ye@intel.com>