### PR TITLE
remove depth_image_proc when launch

### DIFF
--- a/object_analytics_node/launch/object_analytics.launch.py
+++ b/object_analytics_node/launch/object_analytics.launch.py
@@ -41,12 +41,12 @@ def generate_launch_description():
                         ('rgb/image_rect_color', '/camera/color/image_raw'),
                         ('depth_registered/image_rect',
                          '/camera/aligned_depth_to_color/image_raw'),
-                        ('points', '/camera/depth_registered/points')]),
+                        ('points', '/camera/depth/color/points')]),
 
         # api_composition_cli - depth_image_proc
-        launch_ros.actions.Node(
-            package='composition', node_executable='api_composition_cli', output='screen',
-            arguments=[depth_image_proc, depth_image_proc_plugin]),
+        # launch_ros.actions.Node(
+        #     package='composition', node_executable='api_composition_cli', output='screen',
+        #     arguments=[depth_image_proc, depth_image_proc_plugin]),
 
         # api_composition_cli - movidius_ncs_stream
         launch_ros.actions.Node(
@@ -59,7 +59,7 @@ def generate_launch_description():
             arguments=['--tracking', '--localization'],
             remappings=[
                 ('/object_analytics/detected_objects', '/movidius_ncs_stream/detected_objects'),
-                ('/object_analytics/registered_points', '/camera/depth_registered/points')],
+                ('/object_analytics/registered_points', '/camera/depth/color/points')],
             output='screen'),
 
         # object_analytics_rviz

--- a/object_analytics_node/launch/rviz/default.rviz
+++ b/object_analytics_node/launch/rviz/default.rviz
@@ -92,7 +92,7 @@ Visualization Manager:
       Size (Pixels): 4.5
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /camera/depth_registered/points
+      Topic: /camera/depth/color/points
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true


### PR DESCRIPTION
depth_image_proc will has reduce image transport performance, subscribe pointcloud from camera directly, although there has blue points. To fix later with good performance.