### PR TITLE
Optimize segmentation flow

### DIFF
--- a/object_analytics_node/CMakeLists.txt
+++ b/object_analytics_node/CMakeLists.txt
@@ -160,24 +160,6 @@ if(${BUILD_TRACKING})
     "${node_plugins}object_analytics_node::tracker::TrackingNode;$<TARGET_FILE:tracking_component>\n")
 endif()
 
-add_library(splitter_component SHARED
-  src/splitter/splitter_node.cpp
-  src/splitter/splitter.cpp
-)
-target_compile_definitions(splitter_component
-  PRIVATE "OBJECT_ANALYTICS_NODE_BUILDING_DLL"
-)
-ament_target_dependencies(splitter_component
-  "class_loader"
-  "rclcpp"
-  "sensor_msgs"
-  "pcl_conversions"
-)
-target_link_libraries(splitter_component object_analytics_common)
-rclcpp_register_node_plugins(splitter_component "object_analytics_node::splitter::SplitterNode")
-set(node_plugins
-  "${node_plugins}object_analytics_node::splitter::SplitterNode;$<TARGET_FILE:splitter_component>\n")
-
 add_library(moving_component SHARED
   src/movement/moving_object_node.cpp
   src/movement/moving_objects.cpp
@@ -225,14 +207,6 @@ target_link_libraries(segmenter_component object_analytics_common ${PCL_SEGMENTA
 rclcpp_register_node_plugins(segmenter_component "object_analytics_node::segmenter::SegmenterNode")
 set(node_plugins
   "${node_plugins}object_analytics_node::segmenter::SegmenterNode;$<TARGET_FILE:segmenter_component>\n")
-
-
-install(TARGETS
-  splitter_component
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
 
 install(TARGETS
   object_analytics_node

--- a/object_analytics_node/CMakeLists.txt
+++ b/object_analytics_node/CMakeLists.txt
@@ -203,7 +203,7 @@ ament_target_dependencies(segmenter_component
   "object_analytics_msgs"
   "message_filters"
 )
-target_link_libraries(segmenter_component object_analytics_common ${PCL_SEGMENTATION_LIBRARIES})
+target_link_libraries(segmenter_component object_analytics_common ${PCL_SEGMENTATION_LIBRARIES} lz4)
 rclcpp_register_node_plugins(segmenter_component "object_analytics_node::segmenter::SegmenterNode")
 set(node_plugins
   "${node_plugins}object_analytics_node::segmenter::SegmenterNode;$<TARGET_FILE:segmenter_component>\n")

--- a/object_analytics_node/include/object_analytics_node/segmenter/organized_multi_plane_segmenter.hpp
+++ b/object_analytics_node/include/object_analytics_node/segmenter/organized_multi_plane_segmenter.hpp
@@ -76,7 +76,9 @@ private:
   void segmentPlanes(
     const PointCloudT::ConstPtr & cloud, const pcl::PointCloud<pcl::Normal>::Ptr & normal_cloud,
     pcl::PointCloud<pcl::Label>::Ptr labels, std::vector<pcl::PointIndices> & label_indices);
-  void segmentObjects(
+  void segmentObjects_ConnectComponent(
+    const PointCloudT::ConstPtr & cloud, std::vector<pcl::PointIndices> & cluster_indices);
+  void segmentObjects_KdTree(
     const PointCloudT::ConstPtr & cloud, std::vector<pcl::PointIndices> & cluster_indices);
 
   void applyConfig();
@@ -92,6 +94,8 @@ private:
     euclidean_cluster_comparator_;
   size_t plane_minimum_points_;
   size_t object_minimum_points_;
+  size_t object_maximum_points_;
+  float object_distance_threshold_;
 };
 }  // namespace segmenter
 }  // namespace object_analytics_node

--- a/object_analytics_node/include/object_analytics_node/segmenter/segmenter.hpp
+++ b/object_analytics_node/include/object_analytics_node/segmenter/segmenter.hpp
@@ -65,6 +65,13 @@ public:
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & points,
     ObjectsInBoxes3D::SharedPtr & msg);
 
+  /**
+   * @brief Set ROI cloud sampling step.
+   *
+   * @param[in]     step Sampling step to be used in get roi clouds.
+   */
+  void setSamplingStep(size_t step);
+
 private:
   void getPclPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &, PointCloudT &);
   void getRoiPointCloud(
@@ -80,7 +87,7 @@ private:
 
   std::unique_ptr<AlgorithmProvider> provider_;
 
-  size_t sampling_step_;
+  size_t sampling_step_ = 1;
 };
 }  // namespace segmenter
 }  // namespace object_analytics_node

--- a/object_analytics_node/include/object_analytics_node/segmenter/segmenter.hpp
+++ b/object_analytics_node/include/object_analytics_node/segmenter/segmenter.hpp
@@ -68,6 +68,8 @@ public:
 private:
   void getPclPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr &, PointCloudT &);
   void getRoiPointCloud(
+    const PointCloudT::ConstPtr & cloud, PointCloudT::Ptr & roi_cloud, const Object2D & obj2d);
+  void getRoiPointCloud(
     const PointCloudT::ConstPtr & cloud, const pcl::PointCloud<PointXYZPixel>::Ptr & pixel_pcl,
     PointCloudT::Ptr & roi_cloud, const Object2D & obj2d);
   void getPixelPointCloud(
@@ -77,6 +79,8 @@ private:
   void composeResult(const RelationVector &, ObjectsInBoxes3D::SharedPtr &);
 
   std::unique_ptr<AlgorithmProvider> provider_;
+
+  size_t sampling_step_;
 };
 }  // namespace segmenter
 }  // namespace object_analytics_node

--- a/object_analytics_node/launch/object_analytics_with_ncs.launch.py
+++ b/object_analytics_node/launch/object_analytics_with_ncs.launch.py
@@ -26,10 +26,13 @@ def generate_launch_description():
     # depth_image_proc_plugin = 'depth_image_proc::PointCloudXyzrgbNode'
     default_rviz = os.path.join(get_package_share_directory('object_analytics_node'),
                                 'launch', 'rviz/default.rviz')
+    default_rsconfig = os.path.join(get_package_share_directory('object_analytics_node'), 'launch',
+                                'rs_param.yaml')
     return LaunchDescription([
         # Realsense
         launch_ros.actions.Node(
             package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            arguments=['__params:='+default_rsconfig],
             output='screen'),
 
         # api_composition
@@ -39,7 +42,7 @@ def generate_launch_description():
                         ('rgb/image_rect_color', '/camera/color/image_raw'),
                         ('depth_registered/image_rect',
                          '/camera/aligned_depth_to_color/image_raw'),
-                        ('points', '/camera/depth/color/points')]),
+                        ('points', '/camera/aligned_depth_to_color/color/points')]),
 
         # depth_image_proc
         # TODO: enable depth_image_proc when ros2 image_pipeline is ready
@@ -58,7 +61,8 @@ def generate_launch_description():
             arguments=['--tracking', '--localization'],
             remappings=[
                 ('/object_analytics/detected_objects', '/movidius_ncs_stream/detected_objects'),
-                ('/object_analytics/registered_points', '/camera/depth/color/points')],
+                ('/object_analytics/rgb', '/camera/color/image_raw'),
+                ('/object_analytics/pointcloud', '/camera/aligned_depth_to_color/color/points')],
             output='screen'),
 
         # object_analytics_rviz

--- a/object_analytics_node/launch/object_analytics_with_ncs.launch.py
+++ b/object_analytics_node/launch/object_analytics_with_ncs.launch.py
@@ -26,13 +26,13 @@ def generate_launch_description():
     # depth_image_proc_plugin = 'depth_image_proc::PointCloudXyzrgbNode'
     default_rviz = os.path.join(get_package_share_directory('object_analytics_node'),
                                 'launch', 'rviz/default.rviz')
-    default_rsconfig = os.path.join(get_package_share_directory('object_analytics_node'), 'launch',
-                                'rs_param.yaml')
+    default_rsconfig = os.path.join(get_package_share_directory(
+        'object_analytics_node'), 'launch', 'rs_param.yaml')
     return LaunchDescription([
         # Realsense
         launch_ros.actions.Node(
             package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
-            arguments=['__params:='+default_rsconfig],
+            arguments=['__params:=' + default_rsconfig],
             output='screen'),
 
         # api_composition
@@ -67,7 +67,10 @@ def generate_launch_description():
 
         # object_analytics_rviz
         launch_ros.actions.Node(
-            package='object_analytics_rviz', node_executable='image_publisher', output='screen'),
+            package='object_analytics_rviz', node_executable='image_publisher',
+            remappings=[
+                ('/object_analytics/rgb', '/camera/color/image_raw')],
+            output='screen'),
         launch_ros.actions.Node(
             package='object_analytics_rviz', node_executable='marker_publisher', output='screen'),
 

--- a/object_analytics_node/launch/object_analytics_with_openvino.launch.py
+++ b/object_analytics_node/launch/object_analytics_with_openvino.launch.py
@@ -24,12 +24,16 @@ def generate_launch_description():
     # depth_image_proc_plugin = 'depth_image_proc::PointCloudXyzrgbNode'
     default_yaml = os.path.join(get_package_share_directory('dynamic_vino_sample'), 'param',
                                 'pipeline_object_oss_topic.yaml');
+
     default_rviz = os.path.join(get_package_share_directory('object_analytics_node'), 'launch',
                                 'rviz/default.rviz')
+    default_rsconfig = os.path.join(get_package_share_directory('object_analytics_node'), 'launch',
+                                'rs_param.yaml')
     return LaunchDescription([
         # Realsense
         launch_ros.actions.Node(
             package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
+            arguments=['__params:='+default_rsconfig],
             output='screen'),
 
         # api_composition
@@ -52,7 +56,7 @@ def generate_launch_description():
             package='dynamic_vino_sample', node_executable='pipeline_with_params',
             arguments=['-config', default_yaml],
             remappings=[
-                ('/openvino_toolkit/image_raw', '/object_analytics/rgb'),
+                ('/openvino_toolkit/image_raw', '/camera/color/image_raw'),
                 ('/openvino_toolkit/detected_objects', '/ros2_openvino_toolkit/detected_objects'),
                 ('/openvino_toolkit/images', '/ros2_openvino_toolkit/image_rviz')],
             output='screen'),
@@ -63,7 +67,8 @@ def generate_launch_description():
             arguments=['--tracking', '--localization'],
             remappings=[
                 ('/object_analytics/detected_objects', '/ros2_openvino_toolkit/detected_objects'),
-                ('/object_analytics/registered_points', '/camera/depth/color/points')],
+                ('/object_analytics/rgb', '/camera/color/image_raw'),
+                ('/object_analytics/pointcloud', '/camera/aligned_depth_to_color/color/points')],
             output='screen'),
 
         # object_analytics_rviz

--- a/object_analytics_node/launch/object_analytics_with_openvino.launch.py
+++ b/object_analytics_node/launch/object_analytics_with_openvino.launch.py
@@ -23,17 +23,17 @@ def generate_launch_description():
     # depth_image_proc = 'depth_image_proc'
     # depth_image_proc_plugin = 'depth_image_proc::PointCloudXyzrgbNode'
     default_yaml = os.path.join(get_package_share_directory('dynamic_vino_sample'), 'param',
-                                'pipeline_object_oss_topic.yaml');
+                                'pipeline_object_oss_topic.yaml')
 
     default_rviz = os.path.join(get_package_share_directory('object_analytics_node'), 'launch',
                                 'rviz/default.rviz')
-    default_rsconfig = os.path.join(get_package_share_directory('object_analytics_node'), 'launch',
-                                'rs_param.yaml')
+    default_rsconfig = os.path.join(get_package_share_directory(
+        'object_analytics_node'), 'launch', 'rs_param.yaml')
     return LaunchDescription([
         # Realsense
         launch_ros.actions.Node(
             package='realsense_ros2_camera', node_executable='realsense_ros2_camera',
-            arguments=['__params:='+default_rsconfig],
+            arguments=['__params:=' + default_rsconfig],
             output='screen'),
 
         # api_composition
@@ -73,7 +73,10 @@ def generate_launch_description():
 
         # object_analytics_rviz
         launch_ros.actions.Node(
-            package='object_analytics_rviz', node_executable='image_publisher', output='screen'),
+            package='object_analytics_rviz', node_executable='image_publisher',
+            remappings=[
+                ('/object_analytics/rgb', '/camera/color/image_raw')],
+            output='screen'),
         launch_ros.actions.Node(
             package='object_analytics_rviz', node_executable='marker_publisher', output='screen'),
 

--- a/object_analytics_node/launch/rs_param.yaml
+++ b/object_analytics_node/launch/rs_param.yaml
@@ -1,0 +1,4 @@
+RealSenseCameraNode:
+  ros__parameters:
+    enable_aligned_pointcloud: True
+    enable_pointcloud: False

--- a/object_analytics_node/launch/rviz/default.rviz
+++ b/object_analytics_node/launch/rviz/default.rviz
@@ -92,7 +92,7 @@ Visualization Manager:
       Size (Pixels): 4.5
       Size (m): 0.009999999776482582
       Style: Points
-      Topic: /camera/depth/color/points
+      Topic: /camera/aligned_depth_to_color/color/points
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true

--- a/object_analytics_node/src/segmenter/segmenter_node.cpp
+++ b/object_analytics_node/src/segmenter/segmenter_node.cpp
@@ -22,6 +22,7 @@ namespace object_analytics_node
 {
 namespace segmenter
 {
+#define DEFAULT_SAMPLING  10
 const int SegmenterNode::kMsgQueueSize = 100;
 using object_analytics_node::segmenter::AlgorithmProvider;
 using object_analytics_node::segmenter::AlgorithmProviderImpl;
@@ -40,6 +41,7 @@ SegmenterNode::SegmenterNode()
   sub_sync_seg->registerCallback(
     std::bind(&SegmenterNode::callback, this, std::placeholders::_1, std::placeholders::_2));
   impl_.reset(new Segmenter(std::unique_ptr<AlgorithmProvider>(new AlgorithmProviderImpl())));
+  impl_->setSamplingStep(DEFAULT_SAMPLING);
 }
 
 void SegmenterNode::callback(

--- a/object_analytics_node/tests/CMakeLists.txt
+++ b/object_analytics_node/tests/CMakeLists.txt
@@ -15,7 +15,6 @@ if(${BUILD_TRACKING})
     ${GTEST_LIBRARIES}
     ${PCL_IO_LIBRARIES}
     segmenter_component
-    splitter_component
     tracking_component
   )
 else()
@@ -24,7 +23,6 @@ else()
     ${GTEST_LIBRARIES}
     ${PCL_IO_LIBRARIES}
     segmenter_component
-    splitter_component
   )
 endif()
 
@@ -54,12 +52,6 @@ ament_add_gtest(unittest_segmenter unittest_segmenter.cpp unittest_util.cpp
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 if(TARGET unittest_segmenter)
   target_link_libraries(unittest_segmenter ${UNITEST_LIBRARIES})
-endif()
-
-ament_add_gtest(unittest_splitter unittest_splitter.cpp unittest_util.cpp
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-if(TARGET unittest_splitter)
-  target_link_libraries(unittest_splitter ${UNITEST_LIBRARIES})
 endif()
 
 if(${BUILD_TRACKING})


### PR DESCRIPTION
Optimize segmentation flow by below item:
1. Remove conversion of pointXYZ to pointxyz-pixel, since pointXYZ
   already in ordered state which index aligned with UV coordinate.
2. Down sampling point cloud since we don't need dense point cloud
   to perform segment.
3. Change segment algorithm to KDTree to be more robust to sparse
   point cloud.